### PR TITLE
feat(icons): add support for excalidraw file types in fileIcons

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -541,8 +541,18 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'excalidraw',
-      fileNames: ['excalidraw.json', 'excalidraw.svg', 'excalidraw.png'],
-      fileExtensions: ['excalidraw.json', 'excalidraw.svg', 'excalidraw.png'],
+      fileNames: [
+        'excalidraw',
+        'excalidraw.json',
+        'excalidraw.svg',
+        'excalidraw.png',
+      ],
+      fileExtensions: [
+        'excalidraw',
+        'excalidraw.json',
+        'excalidraw.svg',
+        'excalidraw.png',
+      ],
     },
     {
       name: 'gradle',


### PR DESCRIPTION
This pull request updates the `fileIcons` configuration in `src/core/icons/fileIcons.ts` to enhance support for `excalidraw` file types. The change ensures that the `excalidraw` file type is recognized both by its name and extensions.

File type updates:

* [`src/core/icons/fileIcons.ts`](diffhunk://#diff-90ad265f1687cf6e1c278661d22de76f84d2ed788c6c0fb0694365567746f501L544-R555): Added `excalidraw` as a recognized file name and file extension in the `fileIcons` configuration.# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
- adding excalidraw as explicit extension to support files like `design.excalidraw`

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
